### PR TITLE
Fixed clang compile and bad_alloc error; works on MacOSX

### DIFF
--- a/hmm_lib.c
+++ b/hmm_lib.c
@@ -12,6 +12,7 @@ void dump_memory(void *p, int size);
 
 void viterbi(HMM *hmm_ptr, TRAIN *train_ptr, char *O, FILE *fp_out, FILE *fp_aa, FILE *fp_dna,
 char *head, int whole_genome, int cg, int format){
+  
   double max_dbl = 10000000000.0;
   int debug=0;
 
@@ -53,16 +54,16 @@ probability */
   int dna_id=0;
   int dna_f_id=0;
   int out_nt;
-  int start_t, dna_start_t;
+  int start_t, dna_start_t = 0;
   int end_t;
-  int prev_match;
-  int start_orf;
+  int prev_match = 0;
+  int start_orf = 0;
   int frame;
   double final_score;
 
   int insert[100];
   int delete[100];
-  int insert_id, delete_id;
+  int insert_id = 0, delete_id = 0;
   char *head_short=NULL;
   char delimi[] = " ";
 
@@ -880,8 +881,8 @@ vpath[temp_t] != M1_STATE_1  && vpath[temp_t] != M4_STATE_1){
 	    codon[3] = 0;
 	    int s = 0;
 	    //find the optimal start codon within 30bp up- and downstream of start codon
-	    double e_save;
-            int s_save;
+      double e_save = 0.0;
+      int s_save = 0;
 	    while((!(!strcmp(codon, "TAA") || !strcmp(codon, "TAG") || !strcmp(codon, "TGA"))) && (start_old-1-s-35>=0)) {
 	      if(!strcmp(codon, "ATG") || !strcmp(codon, "GTG") || !strcmp(codon, "TTG")) {
 		utr[0] = 0;
@@ -952,8 +953,8 @@ vpath[temp_t] != M1_STATE_1  && vpath[temp_t] != M4_STATE_1){
 	    codon[3] = 0;
 	    int s = 0;
 	    //find the optimal start codon within 30bp up- and downstream of start codon
-	    double e_save;
-            int s_save;
+      double e_save = 0.0;
+      int s_save = 0;
 	    while((!(!strcmp(codon, "TTA") || !strcmp(codon, "CTA") || !strcmp(codon, "TCA"))) && (end_old-2+s+35 < glen)) {
 	      if(!strcmp(codon, "CAT") || !strcmp(codon, "CAC") || !strcmp(codon, "CAA")) {
 		utr[0] = 0;

--- a/util_lib.c
+++ b/util_lib.c
@@ -134,7 +134,7 @@ void free_imatrix(int **m,int num_row){
 
 int tr2int (char *tr){
 
-  int result;
+  int result = -1;
 
   if      (strcmp(tr, "MM")==0){   result = 0; }
   else if (strcmp(tr, "MI")==0){   result = 1; }
@@ -355,7 +355,7 @@ void get_protein(char *dna, char *protein,  int strand, int whole_genome){
   } 
 }
 
-void print_usage(){
+void print_usage(void){
 
   printf("%s", "USAGE: ./FragGeneScan.pl -s [seq_file_name] -o [output_file_name] -w [1 or 0] -t [train_file_name] (-p [thread_num])\n\n");
   printf("%s", "       Mandatory parameters\n");

--- a/util_lib.h
+++ b/util_lib.h
@@ -19,6 +19,7 @@ int nt2int_rc (char nt);
 
 int trinucleotide (char a, char b, char c);
 double log2(double a);
+void get_rc_dna_indel(char *dna, char *dna1);
 void get_protein(char *dna, char *protein, int strand, int whole_genome);
-void print_usage();
+void print_usage(void);
   


### PR DESCRIPTION
Hi! 

I've been working to get the conda package for [isescan](https://github.com/xiezhq/ISEScan) to work on MacOSX and found that there was a known incompatibility due to a bad_alloc error when it called FragGeneScan.

I figured out that this was due to a different default (smaller and insufficient) heap size for threads on MacOSX. This pull request should fix that.

I've tested that it runs and compiles on MacOSX and Linux.

It would be awesome if you could check that and roll a new official version of FragGeneScan with the update so that will propagate to BioConda.